### PR TITLE
Added replay limit options

### DIFF
--- a/pywb/apps/rewriterapp.py
+++ b/pywb/apps/rewriterapp.py
@@ -723,6 +723,16 @@ class RewriterApp(object):
 
         params = {'url': wb_url.url, 'closest': closest, 'matchType': 'exact', 'filter': '~status:[2-3][0-9][0-9]'}
 
+        # restrict number of records passed through
+        if self.config.get('cdx_replay_results_limit'):
+            limit_value = 100
+            try:
+                limit_value = int(self.config['cdx_replay_results_limit'])
+            except Exception as e:
+                pass
+
+            params['limit'] = limit_value
+
         if wb_url.mod == 'vi_':
             params['content_type'] = self.VIDEO_INFO_CONTENT_TYPE
 


### PR DESCRIPTION
Allows the user to specify the number of CDX entries to be returned by PyWB in replay mode in `config.yaml`. If the key exists in the config, a default value of `100` will be set. If the key has a valid integer value assigned to it, this shall be used has the limit to the number of CDX lines returned.

This value does not affect any CDX query apart from closest match inside web archive replay pages.

```cdx_replay_results_limit: 10```