### PR TITLE
Disabled orig_* field iteration

### DIFF
--- a/pywb/warcserver/index/cdxops.py
+++ b/pywb/warcserver/index/cdxops.py
@@ -310,8 +310,8 @@ def cdx_sort_closest(closest, cdx_iter, limit=10):
 # resolve revisits
 
 # Fields to append from cdx original to revisit
-ORIG_TUPLE = [LENGTH, OFFSET, FILENAME]
-
+#ORIG_TUPLE = [LENGTH, OFFSET, FILENAME]
+ORIG_TUPLE = []
 
 def cdx_resolve_revisits(cdx_iter):
     """


### PR DESCRIPTION
Disabled orig_* fields to force PyWB 2 to do its own revisit lookup rather than relying on the CDX11+3 format, which may contain errant data for some revisit resolutions.