### PR TITLE
fix: sanitise outlook safelinks

### DIFF
--- a/pywb/apps/frontendapp.py
+++ b/pywb/apps/frontendapp.py
@@ -493,6 +493,13 @@ class FrontEndApp(object):
             if environ.get('QUERY_STRING'):
                 wb_url_str += '?' + environ.get('QUERY_STRING')
 
+        safelink_start_regex = r"(.*(gbr0|eur0).*safelinks.protection.outlook.com.*url(=|%3D))"
+
+        if re.match(safelink_start_regex, wb_url_str):
+            # sanitises url of outlook safelinks
+            safelink_end_regex = r"((&|%26|%2F&)data(=|%3D))"
+            wb_url_str = re.sub(safelink_start_regex, "", wb_url_str).split(re.findall(safelink_end_regex, wb_url_str)[0][0], 1)[0]
+
         coll_config = self.get_coll_config(coll)
         if record:
             coll_config['type'] = 'record'


### PR DESCRIPTION
## Description
Python regex library used to identify safe links in URL string. String is then split to remove the safe link prefix & suffix.
From:
https://gbr01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fassets.publishing.service.gov.uk%2Fgovernment%2Fuploads%2Fsystem%2Fuploads%2Fattachment_data%2Ffile%2F955642%2FFlexible_Working_and_You.pdf&data=05%7C01%7COliver.Tillard101%40mod.gov.uk%7C734bf9940b2e4677d00d08dad83e6cf0%7Cbe7760ed5953484bae95d0a16dfa09e5%7C0%7C1%7C638060059881265012%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=8VcZC%2FGr6iJzzn5st9o1yv8DcDHBLPJXDtOaIcognxM%3D&reserved=0

To:
https%3A%2F%2Fassets.publishing.service.gov.uk%2Fgovernment%2Fuploads%2Fsystem%2Fuploads%2Fattachment_data%2Ffile%2F955642%2FFlexible_Working_and_You.pdf

Fix works in my pywb-troubleshooting environment.
https://github.com/mirrorweb/pywb-troubleshooting

## Motivation and Context
TNA have asked for this here:
https://mirrorweb.zendesk.com/agent/tickets/5754

## Screenshots (if appropriate):
Live:
![image](https://user-images.githubusercontent.com/60651886/219702452-aaafb60e-ed51-4994-9c55-8d5a8bad4323.png)

pywb-troubleshooting wr:
![image](https://user-images.githubusercontent.com/60651886/219703013-4ba2933b-3ca7-4eb5-a867-e742f39653e9.png)

pywb-troubleshooting tna:
![image](https://user-images.githubusercontent.com/60651886/219703117-20aec9b7-e455-491a-be6e-5660c8b576ba.png)

## Types of changes
- [ ] Replay fix (fixes a replay specific issue)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
