### PR TITLE
If You run a filter against the live service to only show certain sta…

### DIFF
--- a/pywb/warcserver/index/fuzzymatcher.py
+++ b/pywb/warcserver/index/fuzzymatcher.py
@@ -171,7 +171,7 @@ class FuzzyMatcher(object):
             found = True
             yield cdx
 
-        if found:
+        if found or 'filter' in params:
             return
 
         # if fuzzy matching disabled


### PR DESCRIPTION
…tus codes and there are no results for that filter, PYWB will attempt to ditch your filter and just return the first 100 results it has for that URL.

So, by default PYWB will try to get all 2xx and 3xx results.  If none exist, it will then give you 100 4xx and 5xx results it has for that URL.

I've changed the logic to not do the extra return if filters are supplied to the query. I need this to be tested extensively and confirmed non-destructive before we merge.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Delete where not applicable --->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include Any URLs requiring this change. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Replay fix (fixes a replay specific issue)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added or updated tests to cover my changes.
- [ ] All new and existing tests passed.
